### PR TITLE
Bump logback-classic from 1.0.9 to 1.2.0 in /evaluation-tests

### DIFF
--- a/evaluation-tests/pom.xml
+++ b/evaluation-tests/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.9</version>
+            <version>1.2.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Bumps logback-classic from 1.0.9 to 1.2.0.

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-classic dependency-type: direct:development ...